### PR TITLE
Allow quoted plugin params to include all chars

### DIFF
--- a/lib/processtags.js
+++ b/lib/processtags.js
@@ -47,6 +47,7 @@ var TOPIC_REGEX = /\^topicRedirect\(\s*([~\w<>\s]*),([~\w<>\s]*)\s*\)/;
 var RESPOND_REGEX = /\^respond\(\s*([\w~]*)\s*\)/;
 
 var CUSTOMFUN_REGEX = /\^(\w+)\(([\w<>%,\s\-\&\(\)\"\'\;\:\$]*)\)/;
+var CUSTOMFUN_WITH_QUOTES_REGEX = /\^(\w+)\((\".*\")\)/;
 var WORDNET_REGEX = /(~)(\w[\w]+)/g;
 var STATE_REGEX = /{(.*)}/g;
 
@@ -187,7 +188,7 @@ var replies = function (replyObj, user, options, callback) {
     var redirectMatch = reply.match(REDIRECT_REGEX);
     var topicRedirectMatch = reply.match(TOPIC_REGEX);
     var respondMatch = reply.match(RESPOND_REGEX);
-    var customFunctionMatch = reply.match(CUSTOMFUN_REGEX);
+    var customFunctionMatch = reply.match(CUSTOMFUN_WITH_QUOTES_REGEX) || reply.match(CUSTOMFUN_REGEX);
 
     var match = false;
     if (redirectMatch || topicRedirectMatch || respondMatch || customFunctionMatch) {

--- a/lib/reply/customFunction.js
+++ b/lib/reply/customFunction.js
@@ -26,7 +26,17 @@ module.exports = function (reply, match, options, callback) {
       var main = match[0];
       var pluginName = Utils.trim(match[1]);
       var partsStr = Utils.trim(match[2]);
-      var parts = partsStr.split(",");
+
+      // more involved splitting of params that might have quotes
+      var parts;
+      var splitQuotedParams = partsStr.match(/(?:".*?")+/g);
+      if (splitQuotedParams) {
+        parts = _.map(splitQuotedParams, function (param) {
+          return _.trim(param, '"');
+        });
+      } else {
+        parts = partsStr.split(",");
+      }
 
       debug.verbose("-- Function Arguments --", parts);
       var args = [];

--- a/plugins/test.js
+++ b/plugins/test.js
@@ -82,3 +82,10 @@ exports.getUserId = function(cb) {
   });
 }
 
+exports.countParams = function () {
+  var quotes = _.initial(arguments);
+  var cb = _.last(arguments);
+
+  cb(null, "I found " + _.size(quotes) + " parameters");
+}
+

--- a/test/customfunctions.js
+++ b/test/customfunctions.js
@@ -1,0 +1,92 @@
+var mocha = require("mocha");
+var should  = require("should");
+var help = require("./helpers");
+
+describe('SuperScript Custom Functions', function(){
+  before(help.before("script"));
+
+  describe('Custom functions', function(){
+
+    it("should call a custom function with hyphen", function(done) {
+      bot.reply("user1", "error with function thirty-two", function(err, reply) {
+        reply.string.should.eql("thirty-two");
+        done();
+      });
+    });
+
+
+    it("should call a custom function", function(done) {
+      bot.reply("user1", "custom function", function(err, reply) {
+        reply.string.should.eql("The Definition of function is perform duties attached to a particular office or place or function");
+        done();
+      });
+    });
+
+    it("should continue if error is passed into callback", function(done) {
+      bot.reply("user1", "custom 3 function", function(err, reply) {
+        reply.string.should.eql("backup plan");
+        done();
+      });
+    });
+
+    it("pass a param into custom function", function(done) {
+      bot.reply("user1", "custom 5 function", function(err, reply) {
+        reply.string.should.eql("he likes this");
+        done();
+      });
+    });
+
+    it("pass a param into custom function1", function(done) {
+      bot.reply("user1", "custom 6 function", function(err, reply) {
+        ["he cottons this","he prefers this", "he cares for this", "he loves this", "he pleases this"].should.containEql(reply.string);
+        done();
+      });
+    });
+
+    it("the same function twice with different params", function(done) {
+      bot.reply("user1", "custom 8 function", function(err, reply) {
+        reply.string.should.eql("4 + 3 = 7");
+        done();
+      });
+    });
+
+    it("should not freak out if function does not exist", function(done) {
+      bot.reply("user1", "custom4 function", function(err, reply) {
+        reply.string.should.eql("one + one = 2");
+        done();
+      });
+    });
+
+    it("function in multi-line reply", function(done) {
+      bot.reply("user1", "custom9 function", function(err, reply) {
+        reply.string.should.eql("a\nb\none\n\nmore");
+        done();
+      });
+    });
+
+    it("should treat custom function quote parameters as a single unit", function(done) {
+      bot.reply("user1", "custom 10 function", function(err, reply) {
+        reply.string.should.eql("I found 4 parameters");
+        done();
+      });
+    });
+
+    it("should allow special characters inside quoted params", function(done) {
+      bot.reply("user1", "custom 11 function", function(err, reply) {
+        reply.string.should.eql("I found 2 parameters");
+        done();
+      });
+    });
+
+    it("should follow previous behavior if special characters are present outside of quoted params", function(done) {
+      bot.reply("user1", "custom 12 function", function(err, reply) {
+        reply.string.should.eql("^countParams(special chars without quotes, should still fail!)");
+        done();
+      });
+    });
+
+  });
+
+  after(help.after);
+
+});

--- a/test/fixtures/script/script.ss
+++ b/test/fixtures/script/script.ss
@@ -150,6 +150,15 @@
   ^ ^one()\n\n
   ^ more
 
+  + custom 10 function
+  - ^countParams("quotes are treated as a unit", "second param", "third", "fourth parameter")
+
+  + custom 11 function
+  - ^countParams("a param! with some, special chars'?;:.@#$%^&*()/\|", "second")
+
+  + custom 12 function
+  - ^countParams(special chars without quotes, should still fail!)
+
   // We pull in wordnet and system facts
   + I ~like shoe
   - Wordnet test one

--- a/test/script.js
+++ b/test/script.js
@@ -416,69 +416,6 @@ describe('SuperScript Scripting + Style Interface', function(){
 
   });
 
-
-  describe('Custom functions', function(){
-
-    it("should call a custom function with hyphen", function(done) {
-      bot.reply("user1", "error with function thirty-two", function(err, reply) {
-        reply.string.should.eql("thirty-two");
-        done();
-      });
-    });
-
-
-    it("should call a custom function", function(done) {
-      bot.reply("user1", "custom function", function(err, reply) {
-        reply.string.should.eql("The Definition of function is perform duties attached to a particular office or place or function");
-        done();
-      });
-    });
-
-    it("should continue if error is passed into callback", function(done) {
-      bot.reply("user1", "custom 3 function", function(err, reply) {
-        reply.string.should.eql("backup plan");
-        done();
-      });
-    });
-
-    it("pass a param into custom function", function(done) {
-      bot.reply("user1", "custom 5 function", function(err, reply) {
-        reply.string.should.eql("he likes this");
-        done();
-      });
-    });
-
-    it("pass a param into custom function1", function(done) {
-      bot.reply("user1", "custom 6 function", function(err, reply) {
-        ["he cottons this","he prefers this", "he cares for this", "he loves this", "he pleases this"].should.containEql(reply.string);
-        done();
-      });
-    });
-
-    it("the same function twice with different params", function(done) {
-      bot.reply("user1", "custom 8 function", function(err, reply) {
-        reply.string.should.eql("4 + 3 = 7");
-        done();
-      });
-    });
-
-    it("should not freak out if function does not exist", function(done) {
-      bot.reply("user1", "custom4 function", function(err, reply) {
-        reply.string.should.eql("one + one = 2");
-        done();
-      });
-    });
-
-    it("function in multi-line reply", function(done) {
-      bot.reply("user1", "custom9 function", function(err, reply) {
-        reply.string.should.eql("a\nb\none\n\nmore");
-        done();
-      });
-    });
-
-  });
-
-
   // I moved this to 5 times because there was a odd chance that we could hit the keep message 2/3rds of the time
   describe('Reply Flags', function() {
 


### PR DESCRIPTION
- More lenient regex for detecting plugins that have quotes
- Move all custom function tests to new file
- New tests for this case
